### PR TITLE
Improve `decrypt_and_execute`

### DIFF
--- a/server/decrypt_and_execute.sh
+++ b/server/decrypt_and_execute.sh
@@ -1,45 +1,51 @@
 #!/bin/bash
-# the one executing this script need to have the slurm private key
+# root (entered via sudo) needs to have the slurm private key
 
-set -e
-
-# erster call ist mit EOF file ohne sudo
-
+# First call is without sudo and without arguments
 if [[ $EUID -ne 0 ]] ; then
+    if [[ $# -ne 0 ]]; then
+        echo "Usage: $0 <<EOF"
+        echo "<your encrypted script>"
+        echo "EOF"
+        exit 1
+    fi
     user_name=$(whoami)
-    file_name="run.sh.asc"
-    cat $1 > /keys/$file_name
-    sudo decrypt_and_execute $file_name $user_name
-    exit 0
-fi
+    script=$(mktemp --tmpdir=/keys)
+    cat > "$script"
+    if sudo "$0" "$script" "$user_name"; then
+        echo "Running script"
+        "$script"
+    fi
+    res=$?
 
-if [ -z "$2" ]; then
+    echo "Clean up"
+    rm -f /keys/*
+
+    exit $res
+elif [[ $# -eq 0 ]]; then
     echo "Please don't execute this script with sudo" >&2
     exit 1
 fi
 
-file_name=$1
-user_name=$2
+encrypted_script=${1:?Missing encrypted file}
+user_name=${2:?Missing user}
+decrypted_script="${encrypted_script}.dec"
 
-echo "Decrypting.."
-gpg --no-tty --output /keys/run.sh --decrypt /keys/run.sh.asc
+echo -n "Decrypting..."
+if out=$(gpg --no-tty --output "$decrypted_script" --decrypt "$encrypted_script" 2>&1); then
+    echo "OK"
 
-#remove signed script and encrypted
-rm /keys/run.sh.asc
+    run_script=$encrypted_script
+    mv -f "$decrypted_script" "$run_script" || exit 1
 
-chown $user_name: /keys/run.sh
+    if ! chmod +x "$run_script" || ! chown "$user_name" "$run_script"; then
+        echo "Failed to set permissions" >&2
+        exit 1
+    fi
+else
+    echo "Failed"
+    echo "$out" >&2
+    [[ ! -f $decrypted_script ]] || rm "$decrypted_script"
+    exit 1
+fi
 
-sudo -u $user_name chmod +x /keys/run.sh
-
-# trouble running the script resulted in the next line
-#sudo -u $user_name dos2unix -k -o /keys/run.sh
-
-echo "Changing directory"
-cd /usr/users/$user_name
-echo "Running script"
-sudo -u $user_name /keys/run.sh
-
-echo "Clean up"
-
-# remove everything in /keys, the standard should be, that every user has clean directory
-sudo rm -f /keys/*


### PR DESCRIPTION
This is our current approach in case you might find it useful.

- (Better) ensure cleanup of /keys (might be skipped due to `set -e`)
- Add usage message
- Improved error handling (e.g. missing parameters, status/error messages)
- Use a unique script filename
- Decrypt "inplace" to avoid need to change directory
- Exit with "correct" exit code, e.g. a failure when the (decrypted) script didn't succeed.

Noteworthy changes compare to original:

1. Cleanup is not performed by sudo user, but that should be OK
2. The working directory is not changed

Especially the latter point might make it easier for users to reason about their scripts behavior as an encrypted script will behave (more) similar to the unencrypted one.   
However the naive approach of a `cd` to the original `$PWD` inside the "sudo"-part of the script triggered a failure when the PWD is in a user-readable directory with rootsquash enabled where root hence cannot enter.   
Hence the approach of decrypting the script inplace (at least it appears so) and switching back to the user context for running it.